### PR TITLE
refactor: move get_device_name and get_interface_name

### DIFF
--- a/src/nextsec/firewall/__init__.py
+++ b/src/nextsec/firewall/__init__.py
@@ -123,6 +123,11 @@ def add_trusted_zone(uci, name, networks = []):
     uci.set("firewall", flan, "src", name)
     uci.set("firewall", flan, "dest", "lan")
 
+    flan = f"lan2{zname}"
+    uci.set("firewall", flan, "forwarding")
+    uci.set("firewall", flan, "src", "lan")
+    uci.set("firewall", flan, "dest", name)
+
     flan = f"{zname}2wan"
     uci.set("firewall", flan, "forwarding")
     uci.set("firewall", flan, "src", name)

--- a/src/nextsec/firewall/__init__.py
+++ b/src/nextsec/firewall/__init__.py
@@ -13,44 +13,6 @@ import json
 import subprocess
 from nextsec import utils
 
-def get_device_name(hwaddr):
-    '''
-    Retrieve the physical device name given the MAC address
-
-    Aarguments:
-      hwaddr -- MAC address string
-
-    Returns:
-      The device name as a string if the network interface has been found, None otherwise.
-    '''
-    try:
-        interfaces = json.loads(subprocess.run(["/sbin/ip", "--json", "address", "show"], check=True, capture_output=True).stdout)
-        for interface in interfaces:
-            if interface["address"] == hwaddr:
-                return interface["ifname"]
-    except:
-        return None
-
-    return None
-
-def get_interface_name(uci, hwaddr):
-    '''
-    Retrieve the logical UCI interface name given the MAC address
-
-    Arguments:
-      uci -- EUci pointer
-      hwaddr -- MAC address string
-
-    Returns:
-      The device name as a string if the interface has been found, None otherwise
-    '''
-    name = get_device_name(hwaddr)
-    for section in uci.get("network"):
-        if  uci.get("network", section) == "interface" and (uci.get("network", section, "device") == name):
-            return section
-
-    return None
-
 def add_to_zone(uci, device, zone):
     '''
     Add given device to a firewall zone.

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -1,12 +1,6 @@
 import pytest
 from euci import EUci, UciExceptionNotFound 
 from nextsec import firewall
-from unittest.mock import MagicMock, patch
-
-# Setup fake ip command output
-ip_json='[{"ifindex":9,"ifname":"vnet3","flags":["BROADCAST","MULTICAST","UP","LOWER_UP"],"mtu":1500,"qdisc":"noqueue","master":"virbr2","operstate":"UNKNOWN","group":"default","txqlen":1000,"link_type":"ether","address":"fe:62:31:19:0b:29","broadcast":"ff:ff:ff:ff:ff:ff","addr_info":[{"family":"inet6","local":"fe80::fc62:31ff:fe19:b29","prefixlen":64,"scope":"link","valid_life_time":4294967295,"preferred_life_time":4294967295}]}]'
-mock_ip_stdout = MagicMock()
-mock_ip_stdout.configure_mock(**{"stdout": ip_json})
 
 firewall_db = """
 config zone lan1
@@ -44,25 +38,6 @@ def _setup_db(tmp_path):
     with tmp_path.joinpath('network').open('w') as fp:
         fp.write(network_db)
     return EUci(confdir=tmp_path.as_posix())
-
-@patch("nextsec.firewall.subprocess.run")
-def test_get_device_name_valid(mock_run):
-    # setup mock
-    mock_run.return_value = mock_ip_stdout
-
-    assert firewall.get_device_name("fe:62:31:19:0b:29") == 'vnet3'
-
-def test_get_device_name_not_valid():
-    assert firewall.get_device_name("aa:bb:cc:dd:66:55") == None
-
-@patch("nextsec.firewall.subprocess.run")
-def test_get_interface_name(mock_run2, tmp_path):
-    # setup mock
-    mock_run2.return_value = mock_ip_stdout
-    u = _setup_db(tmp_path)
-
-    assert firewall.get_interface_name(u, "fe:62:31:19:0b:29") == 'lan'
-    assert firewall.get_interface_name(u, "aa:bb:cc:dd:66:55") == None
 
 def test_add_to_zone(tmp_path):
     u = _setup_db(tmp_path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,12 @@
 import pytest
 from nextsec import utils
 from euci import EUci
+from unittest.mock import MagicMock, patch
+
+# Setup fake ip command output
+ip_json='[{"ifindex":9,"ifname":"vnet3","flags":["BROADCAST","MULTICAST","UP","LOWER_UP"],"mtu":1500,"qdisc":"noqueue","master":"virbr2","operstate":"UNKNOWN","group":"default","txqlen":1000,"link_type":"ether","address":"fe:62:31:19:0b:29","broadcast":"ff:ff:ff:ff:ff:ff","addr_info":[{"family":"inet6","local":"fe80::fc62:31ff:fe19:b29","prefixlen":64,"scope":"link","valid_life_time":4294967295,"preferred_life_time":4294967295}]}]'
+mock_ip_stdout = MagicMock()
+mock_ip_stdout.configure_mock(**{"stdout": ip_json})
 
 test_db = """
 config mytype section1
@@ -15,10 +21,17 @@ config mytype2 section3
 	option name 'myname3'
 """
 
+network_db = """
+config interface lan
+	option device 'vnet3'
+"""
+
 def _setup_db(tmp_path):
      # setup fake db
     with tmp_path.joinpath('test').open('w') as fp:
         fp.write(test_db)
+    with tmp_path.joinpath('network').open('w') as fp:
+        fp.write(network_db)
     return EUci(confdir=tmp_path.as_posix())
 
 def test_sanitize():
@@ -52,3 +65,22 @@ def test_get_all_by_type(tmp_path):
     assert records['section1']['name'] == 'myname1'
     assert records['section2']['name'] == 'myname2'
     assert records['section2']['opt1'] == ('val1', 'val2')
+
+@patch("nextsec.utils.subprocess.run")
+def test_get_device_name_valid(mock_run):
+    # setup mock
+    mock_run.return_value = mock_ip_stdout
+
+    assert utils.get_device_name("fe:62:31:19:0b:29") == 'vnet3'
+
+def test_get_device_name_not_valid():
+    assert utils.get_device_name("aa:bb:cc:dd:66:55") == None
+
+@patch("nextsec.utils.subprocess.run")
+def test_get_interface_name(mock_run2, tmp_path):
+    # setup mock
+    mock_run2.return_value = mock_ip_stdout
+    u = _setup_db(tmp_path)
+
+    assert utils.get_interface_name(u, "fe:62:31:19:0b:29") == 'lan'
+    assert utils.get_interface_name(u, "aa:bb:cc:dd:66:55") == None


### PR DESCRIPTION
Above methods have been moved under utils sinece
they do not strictly belong to the firewall.